### PR TITLE
Replace set-output with env files

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           BUILD_DATE=$(date '+%Y-%m-%dT%H:%M:%S%:z')
           echo "**** Setting build date to $BUILD_DATE ****"
-          echo ::set-output name=build_date::${BUILD_DATE}
+          echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
       - 
         name: Generate release version
         id: gen_release
@@ -95,8 +95,8 @@ jobs:
           fi
           APP_VERSION=$(echo ${IMAGE_VERSION} | awk -F'-ls' '{print $1}')
           echo "**** Setting release tag to $IMAGE_VERSION ****"
-          echo ::set-output name=tag_name::${IMAGE_VERSION}
-          echo ::set-output name=app_version::${APP_VERSION}
+          echo "tag_name=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
+          echo "app_version=${APP_VERSION}" >> $GITHUB_OUTPUT
       -
         name: Build and push
         uses: docker/bake-action@v2.3.0

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           BUILD_DATE=$(date '+%Y-%m-%dT%H:%M:%S%:z')
           echo "**** Setting build date to $BUILD_DATE ****"
-          echo ::set-output name=build_date::${BUILD_DATE}
+          echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
       - 
         name: Generate release version
         id: gen_release
@@ -104,8 +104,8 @@ jobs:
           fi
           APP_VERSION=$(echo ${IMAGE_VERSION} | awk -F'-ls' '{print $1}')
           echo "**** Setting release tag to $IMAGE_VERSION ****"
-          echo ::set-output name=tag_name::${IMAGE_VERSION}
-          echo ::set-output name=app_version::${APP_VERSION}
+          echo "tag_name=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
+          echo "app_version=${APP_VERSION}" >> $GITHUB_OUTPUT
       -
         name: Build and push
         uses: docker/bake-action@v2.3.0
@@ -123,7 +123,7 @@ jobs:
         name: Dump Tags
         id: dump_tags
         run: |
-          echo ::set-output name=meta-${{ matrix.arch }}::${{ fromJSON(steps.docker_meta.outputs.json).tags[0] }}
+          echo "meta-${{ matrix.arch }}=${{ fromJSON(steps.docker_meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
 
   manifest:
     runs-on: ubuntu-latest
@@ -161,9 +161,9 @@ jobs:
           if [[ -n $ARM32 ]]; then TAG_NAME=$(echo ${{ needs.bake.outputs.meta-arm32v7 }} | cut -f 2- -d ':' | cut -f 2- -d '-'); ARM32="${{ matrix.registry }}/${ARM32}"; fi
           EXTRA_IMAGES=$(echo $AMD64 $ARM64 $ARM32 | tr ' ' ',')
           FINAL_IMAGE=ghcr.io/${{ inputs.repo_owner }}/${{ inputs.app_name }}:${TAG_NAME}
-          echo ::set-output name=extra_images::${EXTRA_IMAGES}
-          echo ::set-output name=tag_name::${TAG_NAME}
-          echo ::set-output name=final_image::${FINAL_IMAGE}
+          echo "extra_images=${EXTRA_IMAGES}" >> $GITHUB_OUTPUT
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "final_image=${FINAL_IMAGE}" >> $GITHUB_OUTPUT
       - 
         name: Create and push manifest for tag
         uses: Noelware/docker-manifest-action@master

--- a/.github/workflows/check-and-release.yml
+++ b/.github/workflows/check-and-release.yml
@@ -125,22 +125,22 @@ jobs:
 
         if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
           echo "**** Version ${EXT_RELEASE} already pushed, not releasing ****"
-          echo ::set-output name=update_available::false
+          echo "update_available=false" >> $GITHUB_OUTPUT
           exit 0
         fi
 
         echo "**** Version ${EXT_RELEASE} has not been pushed, releasing ****"
         echo "**** LS_VERSION set to $LS_VERSION ****"
-        echo ::set-output name=update_available::true
+        echo "update_available=true" >> $GITHUB_OUTPUT
         IMAGE_RELEASE=${EXT_RELEASE}
-        echo ::set-output name=image_release::${IMAGE_RELEASE}
-        echo ::set-output name=ls_version::${LS_VERSION}
-        echo ::set-output name=app_name::${{ inputs.app_name }}
+        echo "image_release=${IMAGE_RELEASE}" >> $GITHUB_OUTPUT
+        echo "ls_version=${LS_VERSION}" >> $GITHUB_OUTPUT
+        echo "app_name=${{ inputs.app_name }}" >> $GITHUB_OUTPUT
 
         if ${{ inputs.prerelease }} == 'true'; then
-          echo ::set-output name=prerelease::true
+          echo "prerelease=true" >> $GITHUB_OUTPUT
         else
-          echo ::set-output name=prerelease::false
+          echo "prerelease=false" >> $GITHUB_OUTPUT
         fi
 
   release:
@@ -157,7 +157,7 @@ jobs:
         run: |
           TAG_NAME="${{ needs.check.outputs.image_release }}-${{ needs.check.outputs.ls_version }}"
           echo "**** Setting release tag to $TAG_NAME ****"
-          echo ::set-output name=tag_name::${TAG_NAME}
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
       - 
         name: Do release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/check-baseimage-update.yml
+++ b/.github/workflows/check-baseimage-update.yml
@@ -47,9 +47,9 @@ jobs:
             jq -r 'first(.[].published_at)') +%s)
           if [ $BASETIME -le $RELEASETIME ]; then
               echo "*** Baseimage release is older than latest container release, skipping ***"
-              echo ::set-output name=modified::false
+              echo "modified=false" >> $GITHUB_OUTPUT
           else
-              echo ::set-output name=modified::true
+              echo "modified=true" >> $GITHUB_OUTPUT
           fi
 
   release:
@@ -69,13 +69,13 @@ jobs:
           LS_VERSION=$(( $(echo $IMAGE_VERSION | awk -NF '-' '{print $NF}' | cut -c 3-8 | sed 's/^0*//')+1 ))
           RELEASE_TAG=$APP_VERSION-ls$(printf $LS_VERSION)
           echo "**** Setting release tag to $RELEASE_TAG ****"
-          echo ::set-output name=tag_name::${RELEASE_TAG}
+          echo "tag_name=${RELEASE_TAG}" >> $GITHUB_OUTPUT
 
           echo "**** Prerelease type is ${{ inputs.prerelease }}"
           if ${{ inputs.prerelease }} == 'true'; then
-            echo ::set-output name=prerelease::true
+            echo "prerelease=true" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=prerelease::false
+            echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
       - 
         name: Do release


### PR DESCRIPTION
To make actions compliant with https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/