### PR TITLE
Remove unused ci-skip

### DIFF
--- a/.github/workflows/check-and-release.yml
+++ b/.github/workflows/check-and-release.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci-skip]')"
     outputs:
       image_release: ${{ steps.build_check.outputs.image_release }}
       ls_version: ${{ steps.build_check.outputs.ls_version }}
@@ -42,7 +41,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    
+
     - name: Check if we should release
       id: build_check
       run: |
@@ -65,7 +64,7 @@ jobs:
               EXT_RELEASE=$(bash "./get-version.sh");
             fi
             ;;
-        esac      
+        esac
         if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
           echo "**** Can't retrieve external version, exiting ****"
           exit 1
@@ -168,18 +167,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     if:  ${{ needs.check.outputs.update_available == 'true' }}
-    steps:  
-      - 
+    steps:
+      -
         name: Checkout
         uses: actions/checkout@v4
-      - 
+      -
         name: Generate release tag
         id: gen_tags
         run: |
           TAG_NAME="${{ needs.check.outputs.image_release }}-${{ needs.check.outputs.ls_version }}"
           echo "**** Setting release tag to $TAG_NAME ****"
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
-      - 
+      -
         name: Do release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
* Bump docker/login-action from 2.1.0 to 2.2.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/77
* Bump docker/setup-buildx-action from 2.5.0 to 2.6.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/79
* Bump docker/metadata-action from 4.4.0 to 4.5.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/78
* Bump docker/setup-buildx-action from 2.6.0 to 2.7.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/80
* Bump docker/bake-action from 3.0.1 to 3.1.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/81
* Bump docker/metadata-action from 4.5.0 to 4.6.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/82
* Bump docker/setup-buildx-action from 2.7.0 to 2.8.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/83
* Bump docker/setup-buildx-action from 2.8.0 to 2.9.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/84
* Bump docker/setup-buildx-action from 2.9.0 to 2.9.1 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/85
* Bump docker/setup-buildx-action from 2.9.1 to 2.10.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/87
* Bump actions/checkout from 3 to 4 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/88
* Bump crazy-max/ghaction-container-scan from 2 to 3 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/89
* Bump docker/bake-action from 3.1.0 to 4.0.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/90
* Bump docker/setup-buildx-action from 2.10.0 to 3.0.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/91
* Bump Noelware/docker-manifest-action from 0.3.1 to 0.4.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/86
* Bump docker/login-action from 2.2.0 to 3.0.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/92
* Bump docker/setup-qemu-action from 2 to 3 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/94
* Bump docker/metadata-action from 4.6.0 to 5.0.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/93
* Bump docker/bake-action from 4.0.0 to 4.1.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/95
* Bump docker/metadata-action from 5.0.0 to 5.2.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/96
* Bump docker/metadata-action from 5.2.0 to 5.5.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/99
* Bump Noelware/docker-manifest-action from 0.4.0 to 0.4.1 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/100
* Bump docker/metadata-action from 5.5.0 to 5.5.1 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/101
* Bump docker/bake-action from 4.1.0 to 4.2.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/104
* Bump docker/setup-buildx-action from 3.0.0 to 3.2.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/106
* Bump docker/login-action from 3.0.0 to 3.1.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/105
* Bump docker/bake-action from 4.2.0 to 4.3.0 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/107
* Bump softprops/action-gh-release from 1 to 2 by @dependabot in https://github.com/linuxserver-labs/docker-actions/pull/103