### PR TITLE
Release v7

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -122,13 +122,13 @@ jobs:
         env:
           BAKE_METADATA: ${{ steps.build_push.outputs.metadata }}
         run: |
-          image_digest=$(jq -rc '.[]."containerimage.digest"' <<< "${BAKE_METADATA}")
-          echo ${image_digest}
+          DIGEST=$(jq -rc '.[]."containerimage.digest"' <<< "${BAKE_METADATA}")
+          echo "Image digest: ${DIGEST}"
           echo "image_digest=${DIGEST}" >> $GITHUB_OUTPUT
       -
         name: Load Key
         id: op-load-key
-        uses: 1password/load-secrets-action@v1
+        uses: 1password/load-secrets-action@v2
         with:
           export-env: true
         env:
@@ -137,7 +137,7 @@ jobs:
       -
         name: Load Pass
         id: op-load-pass
-        uses: 1password/load-secrets-action@v1
+        uses: 1password/load-secrets-action@v2
         with:
           export-env: true
         env:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,9 +21,6 @@ on:
       release_name:
         required: false
         type: string
-    secrets:
-      scarf_token:
-        required: true
 
 jobs:
   bake:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -32,7 +32,7 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
-      -  
+      -
         name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v5.5.1
@@ -50,20 +50,23 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
       -
+        name: Install Cosign
+        uses: sigstore/cosign-installer@v3.5.0
+      -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3.1.0
         with:
           registry: ghcr.io
           username: ${{ inputs.repo_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - 
+      -
         name: Generate build date
         id: gen_date
         run: |
           BUILD_DATE=$(date '+%Y-%m-%dT%H:%M:%S%:z')
           echo "**** Setting build date to $BUILD_DATE ****"
           echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
-      - 
+      -
         name: Generate release version
         id: gen_release
         run: |
@@ -99,6 +102,7 @@ jobs:
           echo "app_version=${APP_VERSION}" >> $GITHUB_OUTPUT
       -
         name: Build and push
+        id: build_push
         uses: docker/bake-action@v4.3.0
         with:
           files: |
@@ -111,6 +115,38 @@ jobs:
           targets: ${{ inputs.target-arch }}
           push: true
           provenance: false
+          sbom: true
+      -
+        name: Load Key
+        id: op-load-key
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          COSIGN_PRIVATE_KEY: op://Labs/labs-sigstore-key/notesPlain
+      -
+        name: Load Pass
+        id: op-load-pass
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          COSIGN_PASSWORD: op://Labs/labs-sigstore-pass/password
+      -
+        name: Sign image with a key
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${images}
+        env:
+          TAGS: ${{ steps.docker_meta.outputs.tags }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          DIGEST: ${{ fromJSON(steps.build_push.outputs.metadata.containerimage.digest) }}
       -
         name: Scan for vulnerabilities
         id: scan
@@ -118,15 +154,3 @@ jobs:
         with:
           image: ${{ fromJSON(steps.docker_meta.outputs.json).tags[0] }}
           dockerfile: ./Dockerfile
-      -
-        name: Push to Scarf
-        id: push_scarf
-        run: |
-          PACKAGE_UUID=$(curl -s -H "Authorization: Bearer ${{ secrets.scarf_token }}" https://scarf.sh/api/v1/organizations/linuxserver-ci/packages | jq -r '.[] | select(.name=="${{ inputs.repo_owner }}/${{ inputs.app_name }}") | .uuid')
-          if [ -z "${PACKAGE_UUID}" ]; then
-            echo "Adding package to Scarf.sh"
-            curl -sX POST https://scarf.sh/api/v1/organizations/linuxserver-ci/packages -H "Authorization: Bearer ${{ secrets.scarf_token }}" -H "Content-Type: application/json" \
-              -d '{"name":"${{ inputs.repo_owner }}/${{ inputs.app_name }}","shortDescription":"example description","libraryType":"docker","website":"https://github.com/${{ inputs.repo_owner }}/docker-${{ inputs.app_name }}","backendUrl":"https://ghcr.io/${{ inputs.repo_owner }}/${{ inputs.app_name }}","publicUrl":"https://lscr.io/${{ inputs.repo_owner }}/${{ inputs.app_name }}"}'
-          else
-            echo "Package already exists on Scarf.sh"
-          fi

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -122,7 +122,8 @@ jobs:
         env:
           BAKE_METADATA: ${{ steps.build_push.outputs.metadata }}
         run: |
-          image_digest=$(jq -c '.[]."containerimage.digest"' <<< "${BAKE_METADATA}")
+          image_digest=$(jq -rc '.[]."containerimage.digest"' <<< "${BAKE_METADATA}")
+          echo ${image_digest}
           echo "image_digest=${DIGEST}" >> $GITHUB_OUTPUT
       -
         name: Load Key

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -140,14 +140,6 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           COSIGN_PRIVATE_KEY: op://Labs/labs-sigstore-key/notesPlain
-      -
-        name: Load Pass
-        id: op-load-pass
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           COSIGN_PASSWORD: op://Labs/labs-sigstore-pass/password
       -
         name: Sign image with a key

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -43,6 +43,12 @@ jobs:
             org.opencontainers.image.title=${{ inputs.app_name }}
             org.opencontainers.image.description=${{ inputs.app_name }}
             org.opencontainers.image.vendor=${{ inputs.repo_owner }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,6 +21,9 @@ on:
       release_name:
         required: false
         type: string
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        required: true
 
 jobs:
   bake:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -129,7 +129,7 @@ jobs:
         id: op-load-key
         uses: 1password/load-secrets-action@v1
         with:
-          export-env: false
+          export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           COSIGN_PRIVATE_KEY: op://Labs/labs-sigstore-key/notesPlain
@@ -138,7 +138,7 @@ jobs:
         id: op-load-pass
         uses: 1password/load-secrets-action@v1
         with:
-          export-env: false
+          export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           COSIGN_PASSWORD: op://Labs/labs-sigstore-pass/password
@@ -152,8 +152,7 @@ jobs:
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${images}
         env:
           TAGS: ${{ steps.docker_meta.outputs.tags }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          DIGEST: ${{ steps.get_digest.outputs.image_digest }}
       -
         name: Scan for vulnerabilities
         id: scan

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -117,6 +117,14 @@ jobs:
           provenance: false
           sbom: true
       -
+        name: Get Digest
+        id: get_digest
+        env:
+          BAKE_METADATA: ${{ steps.build_push.outputs.metadata }}
+        run: |
+          image_digest=$(jq -c '.[]."containerimage.digest"' <<< "${BAKE_METADATA}")
+          echo "image_digest=${DIGEST}" >> $GITHUB_OUTPUT
+      -
         name: Load Key
         id: op-load-key
         uses: 1password/load-secrets-action@v1
@@ -146,7 +154,6 @@ jobs:
           TAGS: ${{ steps.docker_meta.outputs.tags }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          DIGEST: ${{ steps.build_push.outputs.metadata.containerimage.digest }}
       -
         name: Scan for vulnerabilities
         id: scan

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -146,7 +146,7 @@ jobs:
           TAGS: ${{ steps.docker_meta.outputs.tags }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
-          DIGEST: ${{ fromJSON(steps.build_push.outputs.metadata.containerimage.digest) }}
+          DIGEST: ${{ steps.build_push.outputs.metadata.containerimage.digest }}
       -
         name: Scan for vulnerabilities
         id: scan

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -197,10 +197,20 @@ jobs:
           IFS=',' read -r -a IMAGES <<< "${{ steps.image_tags.outputs.extra_images }}"
           for i in "${IMAGES[@]}"; do
             i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
-            export DIGEST=$(docker buildx imagetools inspect --raw ${MANIFESTIMAGE}:${i}-latest | jq -r '.manifests[0].digest') && \
+            DIGEST=$(docker buildx imagetools inspect --raw ${MANIFESTIMAGE}:${i}-latest | jq -r '.manifests[0].digest') && \
             echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest with digest ${DIGEST}"
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}@${DIGEST}
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}@${DIGEST}
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-latest@${DIGEST}
           done
+          case "${{ matrix.registry }}" in
+            "ghcr.io") AUTH_URL="https://ghcr.io/token?scope=repository%3A${{ inputs.repo_owner }}%2F${{ inputs.app_name }}%3Apull"; REGISTRY="ghcr.io";;
+            "docker.io") AUTH_URL="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${{ inputs.repo_owner }}/${{ inputs.app_name }}:pull"; REGISTRY="registry-1.docker.io";;
+          esac
+          TOKEN="$(curl -s -f --retry 10 --retry-max-time 60 --retry-connrefused "${AUTH_URL}" | jq -r '.token')"
+          DIGEST=$(curl -s -L --retry 10 --retry-max-time 60 --retry-connrefused -I -H "Authorization: Bearer ${TOKEN}" --header "Accept: application/vnd.docker.distribution.manifest.v2+json" --header "Accept: application/vnd.oci.image.index.v1+json" https://${REGISTRY}/v2/${{ inputs.repo_owner }}/${{ inputs.app_name }}/manifests/latest 2>&1 | grep docker-content-digest | cut -d' ' -f2)
+          echo "Signing ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:latest with digest ${DIGEST}"
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}@${DIGEST}
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:latest@${DIGEST}
         env:
           EXT_RELEASE_TAG: ${{ steps.image_tags.outputs.tag_name }}
           MANIFESTIMAGE: ${{ matrix.registry }}/${{ inputs.repo_owner }}/${{ inputs.app_name }}

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -51,15 +51,18 @@ jobs:
             org.opencontainers.image.vendor=${{ inputs.repo_owner }}
           flavor: |
             prefix=${{ matrix.arch }}-,onlatest=true
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
-      -
-        name: Install Cosign
-        uses: sigstore/cosign-installer@v3.5.0
       -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3.1.0
@@ -153,6 +156,9 @@ jobs:
           registry: ghcr.io
           username: ${{ inputs.repo_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Install Cosign
+        uses: sigstore/cosign-installer@v3.5.0
       -
         name: Create image tags
         id: image_tags

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -194,10 +194,11 @@ jobs:
             docker buildx imagetools create -t ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest
             docker buildx imagetools create -t ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
           fi
-          for i in ${{ steps.image_tags.outputs.extra_images }}; do
+          IFS=',' read -r -a IMAGES <<< "${{ steps.image_tags.outputs.extra_images }}"
+          for i in "${IMAGES[@]}"; do
             i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
             docker pull ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}
-            export DIGEST=$(docker buildx imagetools inspect --raw ${MANIFESTIMAGE}:arm64v8-latest | jq -r '.manifests[0].digest') && \
+            export DIGEST=$(docker buildx imagetools inspect --raw ${MANIFESTIMAGE}:${i}-latest | jq -r '.manifests[0].digest') && \
             echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest with digest ${DIGEST}"
             cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}@${DIGEST}
           done

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -187,17 +187,11 @@ jobs:
         id: manifest_sign
         run: |
           if [[ ${{ steps.image_tags.outputs.extra_images }} =~ "aarch64" ]]; then
-            docker manifest create ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest ${MANIFESTIMAGE}:aarch64-latest
-            docker manifest annotate ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:aarch64-latest --os linux --arch arm64 --variant v8
-            docker manifest push ${MANIFESTIMAGE}:latest
-            docker manifest create ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:aarch64-${EXT_RELEASE_TAG}
-            docker manifest annotate ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:aarch64-${EXT_RELEASE_TAG} --os linux --arch arm64 --variant v8
-            docker manifest push ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}
+            docker buildx imagetools create -t ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest ${MANIFESTIMAGE}:aarch64-latest
+            docker buildx imagetools create -t  ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:aarch64-${EXT_RELEASE_TAG}
           else
-            docker manifest create ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest
-            docker manifest push ${MANIFESTIMAGE}:latest
-            docker manifest create ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
-            docker manifest push ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}
+            docker buildx imagetools create -t  ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest
+            docker buildx imagetools create -t  ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
           fi
           for i in ${{ steps.image_tags.outputs.extra_images }}; do
             export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-latest -f '{{ index .Id }}')

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -49,6 +49,8 @@ jobs:
             org.opencontainers.image.title=${{ inputs.app_name }}
             org.opencontainers.image.description=${{ inputs.app_name }}
             org.opencontainers.image.vendor=${{ inputs.repo_owner }}
+          flavor: |
+            prefix=${{ matrix.arch }}-
           tags: |
             type=schedule
             type=ref,event=branch

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -202,12 +202,14 @@ jobs:
           IFS=',' read -r -a IMAGES <<< "${{ steps.image_tags.outputs.extra_images }}"
           for i in "${IMAGES[@]}"; do
             i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
-            DIGEST=$(curl -s -L --retry 10 --retry-max-time 60 --retry-connrefused -I -H "Authorization: Bearer ${TOKEN}" --header "Accept: application/vnd.docker.distribution.manifest.v2+json" --header "Accept: application/vnd.oci.image.index.v1+json" https://${REGISTRY}/v2/${MANIFESTIMAGE}/manifests/${i}-latest 2>&1 | grep docker-content-digest | cut -d' ' -f2) && \
+            DIGEST=$(curl -s -L --retry 10 --retry-max-time 60 --retry-connrefused -I -H "Authorization: Bearer ${TOKEN}" --header "Accept: application/vnd.docker.distribution.manifest.v2+json" --header "Accept: application/vnd.oci.image.index.v1+json" https://${REGISTRY}/v2/${MANIFESTIMAGE}/manifests/${i}-latest 2>&1 | grep 'docker-content-digest' | cut -d' ' -f2)
+            DIGEST="${DIGEST//[$'\t\r\n ']}"
             echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest with digest ${DIGEST}"
             cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}@${DIGEST}
             cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-latest@${DIGEST}
           done
-          DIGEST=$(curl -s -L --retry 10 --retry-max-time 60 --retry-connrefused -I -H "Authorization: Bearer ${TOKEN}" --header "Accept: application/vnd.docker.distribution.manifest.v2+json" --header "Accept: application/vnd.oci.image.index.v1+json" https://${REGISTRY}/v2/${MANIFESTIMAGE}/manifests/latest 2>&1 | grep docker-content-digest | cut -d' ' -f2)
+          DIGEST=$(curl -s -L --retry 10 --retry-max-time 60 --retry-connrefused -I -H "Authorization: Bearer ${TOKEN}" --header "Accept: application/vnd.docker.distribution.manifest.v2+json" --header "Accept: application/vnd.oci.image.index.v1+json" https://${REGISTRY}/v2/${MANIFESTIMAGE}/manifests/latest 2>&1 | grep 'docker-content-digest' | cut -d' ' -f2)
+          DIGEST="${DIGEST//[$'\t\r\n ']}"
           echo "Signing ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:latest with digest ${DIGEST}"
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}@${DIGEST}
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:latest@${DIGEST}

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -195,13 +195,18 @@ jobs:
             docker buildx imagetools create -t ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
           fi
           for i in ${{ steps.image_tags.outputs.extra_images }}; do
-            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-latest -f '{{ index .Id }}') && \
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i##*-}-latest@${DIGEST}
-            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i##*-}-${EXT_RELEASE_TAG}@${DIGEST}
+            i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
+            echo "Signing ${MANIFESTIMAGE}:${i}-latest"
+            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i}-latest -f '{{ index .Id }}') && \
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-latest@${DIGEST}
+            echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}"
+            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}@${DIGEST}
           done
+          echo "Signing ${MANIFESTIMAGE}:latest"
           export DIGEST=$(docker inspect ${MANIFESTIMAGE}:latest -f '{{ index .Id }}') && \
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:latest@${DIGEST}
+          echo "Signing ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}"
           export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}@${DIGEST}
         env:

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -168,6 +168,7 @@ jobs:
           if [[ -n $AMD64 ]]; then TAG_NAME=$(echo ${{ needs.bake.outputs.meta-amd64 }} | cut -f 2- -d ':' | cut -f 2- -d '-'); AMD64="${{ matrix.registry }}/${AMD64}"; fi
           if [[ -n $ARM64 ]]; then TAG_NAME=$(echo ${{ needs.bake.outputs.meta-arm64v8 }} | cut -f 2- -d ':' | cut -f 2- -d '-'); ARM64="${{ matrix.registry }}/${ARM64}"; fi
           EXTRA_IMAGES=$(echo $AMD64 $ARM64 | tr ' ' ',')
+          echo "Extra images are: ${EXTRA_IMAGES}"
           FINAL_IMAGE=ghcr.io/${{ inputs.repo_owner }}/${{ inputs.app_name }}:${TAG_NAME}
           echo "extra_images=${EXTRA_IMAGES}" >> $GITHUB_OUTPUT
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
@@ -186,22 +187,22 @@ jobs:
         name: Create manifest and sign image
         id: manifest_sign
         run: |
-          if [[ ${{ steps.image_tags.outputs.extra_images }} =~ "aarch64" ]]; then
-            docker buildx imagetools create -t ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest ${MANIFESTIMAGE}:aarch64-latest
-            docker buildx imagetools create -t  ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:aarch64-${EXT_RELEASE_TAG}
+          if [[ ${{ steps.image_tags.outputs.extra_images }} =~ "arm64v8" ]]; then
+            docker buildx imagetools create -t ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest ${MANIFESTIMAGE}:arm64v8-latest
+            docker buildx imagetools create -t ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm64v8-${EXT_RELEASE_TAG}
           else
-            docker buildx imagetools create -t  ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest
-            docker buildx imagetools create -t  ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
+            docker buildx imagetools create -t ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest
+            docker buildx imagetools create -t ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
           fi
           for i in ${{ steps.image_tags.outputs.extra_images }}; do
-            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-latest -f '{{ index .Id }}')
+            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-latest -f '{{ index .Id }}') && \
             cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i##*-}-latest@${DIGEST}
-            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-${EXT_RELEASE_TAG} -f '{{ index .Id }}')
+            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
             cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i##*-}-${EXT_RELEASE_TAG}@${DIGEST}
           done
-          export DIGEST=$(docker inspect ${MANIFESTIMAGE}:latest -f '{{ index .Id }}')
+          export DIGEST=$(docker inspect ${MANIFESTIMAGE}:latest -f '{{ index .Id }}') && \
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:latest@${DIGEST}
-          export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} -f '{{ index .Id }}')
+          export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}@${DIGEST}
         env:
           EXT_RELEASE_TAG: ${{ steps.image_tags.outputs.tag_name }}

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -49,8 +49,6 @@ jobs:
             org.opencontainers.image.title=${{ inputs.app_name }}
             org.opencontainers.image.description=${{ inputs.app_name }}
             org.opencontainers.image.vendor=${{ inputs.repo_owner }}
-          flavor: |
-            prefix=${{ matrix.arch }}-,onlatest=true
           tags: |
             type=schedule
             type=ref,event=branch
@@ -194,20 +192,20 @@ jobs:
             docker buildx imagetools create -t ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest
             docker buildx imagetools create -t ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
           fi
-          IFS=',' read -r -a IMAGES <<< "${{ steps.image_tags.outputs.extra_images }}"
-          for i in "${IMAGES[@]}"; do
-            i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
-            DIGEST=$(docker buildx imagetools inspect --raw ${MANIFESTIMAGE}:${i}-latest | jq -r '.manifests[0].digest') && \
-            echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest with digest ${DIGEST}"
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}@${DIGEST}
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-latest@${DIGEST}
-          done
           case "${{ matrix.registry }}" in
             "ghcr.io") AUTH_URL="https://ghcr.io/token?scope=repository%3A${{ inputs.repo_owner }}%2F${{ inputs.app_name }}%3Apull"; REGISTRY="ghcr.io";;
             "docker.io") AUTH_URL="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${{ inputs.repo_owner }}/${{ inputs.app_name }}:pull"; REGISTRY="registry-1.docker.io";;
           esac
           TOKEN="$(curl -s -f --retry 10 --retry-max-time 60 --retry-connrefused "${AUTH_URL}" | jq -r '.token')"
-          DIGEST=$(curl -s -L --retry 10 --retry-max-time 60 --retry-connrefused -I -H "Authorization: Bearer ${TOKEN}" --header "Accept: application/vnd.docker.distribution.manifest.v2+json" --header "Accept: application/vnd.oci.image.index.v1+json" https://${REGISTRY}/v2/${{ inputs.repo_owner }}/${{ inputs.app_name }}/manifests/latest 2>&1 | grep docker-content-digest | cut -d' ' -f2)
+          IFS=',' read -r -a IMAGES <<< "${{ steps.image_tags.outputs.extra_images }}"
+          for i in "${IMAGES[@]}"; do
+            i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
+            DIGEST=$(curl -s -L --retry 10 --retry-max-time 60 --retry-connrefused -I -H "Authorization: Bearer ${TOKEN}" --header "Accept: application/vnd.docker.distribution.manifest.v2+json" --header "Accept: application/vnd.oci.image.index.v1+json" https://${REGISTRY}/v2/${MANIFESTIMAGE}/manifests/${i}-latest 2>&1 | grep docker-content-digest | cut -d' ' -f2) && \
+            echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest with digest ${DIGEST}"
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}@${DIGEST}
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-latest@${DIGEST}
+          done
+          DIGEST=$(curl -s -L --retry 10 --retry-max-time 60 --retry-connrefused -I -H "Authorization: Bearer ${TOKEN}" --header "Accept: application/vnd.docker.distribution.manifest.v2+json" --header "Accept: application/vnd.oci.image.index.v1+json" https://${REGISTRY}/v2/${MANIFESTIMAGE}/manifests/latest 2>&1 | grep docker-content-digest | cut -d' ' -f2)
           echo "Signing ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:latest with digest ${DIGEST}"
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}@${DIGEST}
           cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:latest@${DIGEST}

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -196,19 +196,15 @@ jobs:
           fi
           for i in ${{ steps.image_tags.outputs.extra_images }}; do
             i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
-            echo "Signing ${MANIFESTIMAGE}:${i}-latest"
-            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i}-latest -f '{{ index .Id }}') && \
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-latest@${DIGEST}
-            echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}"
+            echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest"
+            docker pull ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}
             export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
-            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}@${DIGEST}
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}@${DIGEST}
           done
-          echo "Signing ${MANIFESTIMAGE}:latest"
-          export DIGEST=$(docker inspect ${MANIFESTIMAGE}:latest -f '{{ index .Id }}') && \
-          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:latest@${DIGEST}
-          echo "Signing ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}"
+          echo "Signing ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:latest"
+          docker pull ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}
           export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
-          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}@${DIGEST}
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}@${DIGEST}
         env:
           EXT_RELEASE_TAG: ${{ steps.image_tags.outputs.tag_name }}
           MANIFESTIMAGE: ${{ matrix.registry }}/${{ inputs.repo_owner }}/${{ inputs.app_name }}

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -196,15 +196,11 @@ jobs:
           fi
           for i in ${{ steps.image_tags.outputs.extra_images }}; do
             i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
-            echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest"
             docker pull ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}
-            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
+            export DIGEST=$(docker buildx imagetools inspect --raw ${MANIFESTIMAGE}:arm64v8-latest | jq -r '.manifests[0].digest') && \
+            echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest with digest ${DIGEST}"
             cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}@${DIGEST}
           done
-          echo "Signing ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:latest"
-          docker pull ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}
-          export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} -f '{{ index .Id }}') && \
-          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}@${DIGEST}
         env:
           EXT_RELEASE_TAG: ${{ steps.image_tags.outputs.tag_name }}
           MANIFESTIMAGE: ${{ matrix.registry }}/${{ inputs.repo_owner }}/${{ inputs.app_name }}

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
     secrets:
-      scarf_token:
+      OP_SERVICE_ACCOUNT_TOKEN:
         required: true
 
 jobs:
@@ -34,12 +34,11 @@ jobs:
     outputs:
       meta-amd64: ${{ steps.dump_tags.outputs.meta-amd64 }}
       meta-arm64v8: ${{ steps.dump_tags.outputs.meta-arm64v8 }}
-      meta-arm32v7: ${{ steps.dump_tags.outputs.meta-arm32v7 }}
     steps:
       -
         name: Checkout
         uses: actions/checkout@v4
-      -  
+      -
         name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v5.5.1
@@ -59,20 +58,23 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
       -
+        name: Install Cosign
+        uses: sigstore/cosign-installer@v3.5.0
+      -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v3.1.0
         with:
           registry: ghcr.io
           username: ${{ inputs.repo_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - 
+      -
         name: Generate build date
         id: gen_date
         run: |
           BUILD_DATE=$(date '+%Y-%m-%dT%H:%M:%S%:z')
           echo "**** Setting build date to $BUILD_DATE ****"
           echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
-      - 
+      -
         name: Generate release version
         id: gen_release
         run: |
@@ -120,6 +122,7 @@ jobs:
           targets: ${{ matrix.arch }}
           push: true
           provenance: false
+          sbom: true
       -
         name: Dump Tags
         id: dump_tags
@@ -144,7 +147,7 @@ jobs:
           password: ${{ secrets.dockerhub_password }}
       -
         name: Login to GitHub Container Registry
-        if: matrix.registry == 'ghcr.io'        
+        if: matrix.registry == 'ghcr.io'
         uses: docker/login-action@v3.1.0
         with:
           registry: ghcr.io
@@ -156,30 +159,53 @@ jobs:
         run: |
           AMD64=$(echo ${{ needs.bake.outputs.meta-amd64 }} | cut -f 2- -d '/')
           ARM64=$(echo ${{ needs.bake.outputs.meta-arm64v8 }} | cut -f 2- -d '/')
-          ARM32=$(echo ${{ needs.bake.outputs.meta-arm32v7 }} | cut -f 2- -d '/')
-          if [[ -n $AMD64 ]];then TAG_NAME=$(echo ${{ needs.bake.outputs.meta-amd64 }} | cut -f 2- -d ':' | cut -f 2- -d '-'); AMD64="${{ matrix.registry }}/${AMD64}"; fi
+          if [[ -n $AMD64 ]]; then TAG_NAME=$(echo ${{ needs.bake.outputs.meta-amd64 }} | cut -f 2- -d ':' | cut -f 2- -d '-'); AMD64="${{ matrix.registry }}/${AMD64}"; fi
           if [[ -n $ARM64 ]]; then TAG_NAME=$(echo ${{ needs.bake.outputs.meta-arm64v8 }} | cut -f 2- -d ':' | cut -f 2- -d '-'); ARM64="${{ matrix.registry }}/${ARM64}"; fi
-          if [[ -n $ARM32 ]]; then TAG_NAME=$(echo ${{ needs.bake.outputs.meta-arm32v7 }} | cut -f 2- -d ':' | cut -f 2- -d '-'); ARM32="${{ matrix.registry }}/${ARM32}"; fi
-          EXTRA_IMAGES=$(echo $AMD64 $ARM64 $ARM32 | tr ' ' ',')
+          EXTRA_IMAGES=$(echo $AMD64 $ARM64 | tr ' ' ',')
           FINAL_IMAGE=ghcr.io/${{ inputs.repo_owner }}/${{ inputs.app_name }}:${TAG_NAME}
           echo "extra_images=${EXTRA_IMAGES}" >> $GITHUB_OUTPUT
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "final_image=${FINAL_IMAGE}" >> $GITHUB_OUTPUT
-      - 
-        name: Create and push manifest for tag
-        uses: Noelware/docker-manifest-action@0.4.1
+      -
+        name: Load Key
+        id: op-load-key
+        uses: 1password/load-secrets-action@v2
         with:
-          base-image: ${{ matrix.registry }}/${{ inputs.repo_owner }}/${{ inputs.app_name }}:${{ steps.image_tags.outputs.tag_name }}
-          extra-images: ${{ steps.image_tags.outputs.extra_images }}
-          push: true          
-      - 
-        name: Create and push manifest for latest
-        if:  ${{ github.event.release.tag_name != '' }}
-        uses: Noelware/docker-manifest-action@0.4.1
-        with:
-          base-image: ${{ matrix.registry }}/${{ inputs.repo_owner }}/${{ inputs.app_name }}:latest
-          extra-images: ${{ steps.image_tags.outputs.extra_images }}
-          push: true
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          COSIGN_PRIVATE_KEY: op://Labs/labs-sigstore-key/notesPlain
+          COSIGN_PASSWORD: op://Labs/labs-sigstore-pass/password
+      -
+        name: Create manifest and sign image
+        id: manifest_sign
+        run: |
+          if [[ ${{ steps.image_tags.outputs.extra_images }} =~ "aarch64" ]]; then
+            docker manifest create ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest ${MANIFESTIMAGE}:aarch64-latest
+            docker manifest annotate ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:aarch64-latest --os linux --arch arm64 --variant v8
+            docker manifest push ${MANIFESTIMAGE}:latest
+            docker manifest create ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:aarch64-${EXT_RELEASE_TAG}
+            docker manifest annotate ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:aarch64-${EXT_RELEASE_TAG} --os linux --arch arm64 --variant v8
+            docker manifest push ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}
+          else
+            docker manifest create ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest
+            docker manifest push ${MANIFESTIMAGE}:latest
+            docker manifest create ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
+            docker manifest push ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}
+          fi
+          for i in ${{ steps.image_tags.outputs.extra_images }}; do
+            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-latest -f '{{ index .Id }}')
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i##*-}-latest@${DIGEST}
+            export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${i##*-}-${EXT_RELEASE_TAG} -f '{{ index .Id }}')
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${i##*-}-${EXT_RELEASE_TAG}@${DIGEST}
+          done
+          export DIGEST=$(docker inspect ${MANIFESTIMAGE}:latest -f '{{ index .Id }}')
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:latest@${DIGEST}
+          export DIGEST=$(docker inspect ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} -f '{{ index .Id }}')
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}@${DIGEST}
+        env:
+          EXT_RELEASE_TAG: ${{ steps.image_tags.outputs.tag_name }}
+          MANIFESTIMAGE: ${{ matrix.registry }}/${{ inputs.repo_owner }}/${{ inputs.app_name }}
 
   finally:
     runs-on: ubuntu-latest
@@ -195,15 +221,3 @@ jobs:
         with:
           image: ${{ needs.manifest.outputs.final-image }}
           dockerfile: ./Dockerfile
-      -
-        name: Push to Scarf
-        id: push_scarf
-        run: |
-          PACKAGE_UUID=$(curl -s -H "Authorization: Bearer ${{ secrets.scarf_token }}" https://scarf.sh/api/v1/organizations/linuxserver-ci/packages | jq -r '.[] | select(.name=="${{ inputs.repo_owner }}/${{ inputs.app_name }}") | .uuid')
-          if [ -z "${PACKAGE_UUID}" ]; then
-            echo "Adding package to Scarf.sh"
-            curl -sX POST https://scarf.sh/api/v1/organizations/linuxserver-ci/packages -H "Authorization: Bearer ${{ secrets.scarf_token }}" -H "Content-Type: application/json" \
-              -d '{"name":"${{ inputs.repo_owner }}/${{ inputs.app_name }}","shortDescription":"example description","libraryType":"docker","website":"https://github.com/${{ inputs.repo_owner }}/docker-${{ inputs.app_name }}","backendUrl":"https://ghcr.io/${{ inputs.repo_owner }}/${{ inputs.app_name }}","publicUrl":"https://lscr.io/${{ inputs.repo_owner }}/${{ inputs.app_name }}"}'
-          else
-            echo "Package already exists on Scarf.sh"
-          fi

--- a/.github/workflows/build-split-image.yml
+++ b/.github/workflows/build-split-image.yml
@@ -197,7 +197,6 @@ jobs:
           IFS=',' read -r -a IMAGES <<< "${{ steps.image_tags.outputs.extra_images }}"
           for i in "${IMAGES[@]}"; do
             i=$(echo $i | cut -d":" -f2 | cut -d"-" -f1)
-            docker pull ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG}
             export DIGEST=$(docker buildx imagetools inspect --raw ${MANIFESTIMAGE}:${i}-latest | jq -r '.manifests[0].digest') && \
             echo "Signing ${MANIFESTIMAGE}:${i}-${EXT_RELEASE_TAG} and ${MANIFESTIMAGE}:${i}-latest with digest ${DIGEST}"
             cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${MANIFESTIMAGE}@${DIGEST}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -29,14 +29,6 @@ target "arm64v8" {
   ]
 }
 
-target "arm32v7" {
-  inherits = ["image"]
-  dockerfile = "Dockerfile.armhf"
-  platforms = [
-    "linux/arm/v7"
-  ]
-}
-
 target "64" {
   inherits = ["image"]
   platforms = [
@@ -48,8 +40,7 @@ target "64" {
 target "arm" {
   inherits = ["image"]
   platforms = [
-    "linux/arm64",
-    "linux/arm/v7"
+    "linux/arm64"
   ]
 }
 
@@ -57,7 +48,6 @@ target "all" {
   inherits = ["image"]
   platforms = [
     "linux/amd64",
-    "linux/arm64",
-    "linux/arm/v7"
+    "linux/arm64"
   ]
 }


### PR DESCRIPTION
* Adds SBOM to all images
* Signs all images with [cosign](https://docs.sigstore.dev/). Use https://linuxserver.io/keys/lsio-labs-signing-key.pub to verify.
  * Uses OP agent for signing key, need to add `OP_SERVICE_ACCOUNT_TOKEN` as org secret
  * Probably need to delete `OP_SERVICE_ACCOUNT_TOKEN` repo secret from monit and playground repos
* Fixes tags when building on branch commits
* Will probably screw up horribly with PR builds, but need to actually merge this first to be able to confirm and then try to fix that.